### PR TITLE
GitHub IO Consistency for "Backwards Compatible" and "Drop-In Compati…

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -119,7 +119,7 @@
         <article class="m-item" style="position: absolute; left: 0px; top: 0px;">
           <header>Seamless Deployment</header>
           <section>
-            The AWS JDBC Driver for PostgreSQL is based on and is backward compatible with the PostgreSQL JDBC Driver,
+            The AWS JDBC Driver for PostgreSQL is based on and is drop-in compatible with the PostgreSQL JDBC Driver,
             so users can replace it in their applications with little code changes.
           </section>
         </article>
@@ -142,7 +142,7 @@
           <section>
             The AWS JDBC Driver for PostgreSQL is compatible with all PostgreSQL deployments, whether they be
             on-premises or in the cloud. It currently enables fast failover capabilities for Amazon Aurora with
-            PostgreSQL compatibility only. The driver is based on and is backward compatible with the PostgreSQL JDBC
+            PostgreSQL compatibility only. The driver is based on and is drop-in compatible with the PostgreSQL JDBC
             Driver. Changes to the connection string is all that is needed. Support for additional features of clustered
             databases, including features of Amazon RDS for PostgreSQL and on-premises PostgreSQL deployments, is
             planned.


### PR DESCRIPTION
…ble".

### Summary

Consistent usage for "drop-in compatible" terminology.

### Description

Consistent usage for "drop-in compatible" terminology used in the GitHub IO page.
