### PR TITLE
GitHub Badges Old Cache Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://github.com/awslabs/aws-postgresql-jdbc/workflows/CI/badge.svg?kill_cache=1)](https://github.com/awslabs/aws-postgresql-jdbc/actions?query=workflow%3A%22CI%22)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/software.aws.rds/aws-postgresql-jdbc/badge.svg?kill_cache=1)](https://maven-badges.herokuapp.com/maven-central/software.aws.rds/aws-postgresql-jdbc)
 [![Javadoc](https://javadoc.io/badge2/software.aws.rds/aws-postgresql-jdbc/javadoc.svg?kill_cache=1)](https://javadoc.io/doc/software.aws.rds/aws-postgresql-jdbc)
-[![License](https://img.shields.io/badge/License-BSD--2--Clause-blue.svg?kill_cache=1)](https://opensource.org/licenses/BSD-2-Clause)
+[![License](https://img.shields.io/badge/License-BSD--2--Clause-blue.svg)](https://opensource.org/licenses/BSD-2-Clause)
 
 **The Amazon Web Services (AWS) JDBC Driver for PostgreSQL** is a driver that enables applications to take full advantage of the features of clustered PostgreSQL databases. It is drop-in compatible and based on the [PostgreSQL JDBC Driver](https://github.com/pgjdbc/pgjdbc), and is compatible with all PostgreSQL deployments.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Amazon Web Services (AWS) JDBC Driver for PostgreSQL
 
-[![Build Status](https://github.com/awslabs/aws-postgresql-jdbc/workflows/CI/badge.svg)](https://github.com/awslabs/aws-postgresql-jdbc/actions?query=workflow%3A%22CI%22)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/software.aws.rds/aws-postgresql-jdbc/badge.svg)](https://maven-badges.herokuapp.com/maven-central/software.aws.rds/aws-postgresql-jdbc)
-[![Javadoc](https://javadoc.io/badge2/software.aws.rds/aws-postgresql-jdbc/javadoc.svg)](https://javadoc.io/doc/software.aws.rds/aws-postgresql-jdbc)
-[![License](https://img.shields.io/badge/License-BSD--2--Clause-blue.svg)](https://opensource.org/licenses/BSD-2-Clause)
+[![Build Status](https://github.com/awslabs/aws-postgresql-jdbc/workflows/CI/badge.svg?kill_cache=1)](https://github.com/awslabs/aws-postgresql-jdbc/actions?query=workflow%3A%22CI%22)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/software.aws.rds/aws-postgresql-jdbc/badge.svg?kill_cache=1)](https://maven-badges.herokuapp.com/maven-central/software.aws.rds/aws-postgresql-jdbc)
+[![Javadoc](https://javadoc.io/badge2/software.aws.rds/aws-postgresql-jdbc/javadoc.svg?kill_cache=1)](https://javadoc.io/doc/software.aws.rds/aws-postgresql-jdbc)
+[![License](https://img.shields.io/badge/License-BSD--2--Clause-blue.svg?kill_cache=1)](https://opensource.org/licenses/BSD-2-Clause)
 
 **The Amazon Web Services (AWS) JDBC Driver for PostgreSQL** is a driver that enables applications to take full advantage of the features of clustered PostgreSQL databases. It is drop-in compatible and based on the [PostgreSQL JDBC Driver](https://github.com/pgjdbc/pgjdbc), and is compatible with all PostgreSQL deployments.
 


### PR DESCRIPTION
### Summary

GitHub will cache older states for our badges. Remove the cache.

### Description

Adds kill_cache=1 to remove the caching.
