### PR TITLE
chore: Set target Java level

### DIFF
--- a/pgjdbc/build.gradle.kts
+++ b/pgjdbc/build.gradle.kts
@@ -31,6 +31,11 @@ buildscript {
     }
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 val shaded by configurations.creating
 
 val karafFeatures by configurations.creating {


### PR DESCRIPTION
### Summary

Set `sourceCompatibility` and `targetCompatibility` to Java 8

### Description

- Ensure project compiles to Java 8

### Additional Reviewers

@sergiyvamz
@congoamz 
@hsuamz 
