### PR TITLE
chore: Update command to start Docker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,8 @@ jobs:
         fetch-depth: 50
     - name: Start PostgreSQL
       working-directory: docker
-      run: docker-compose up -d && docker-compose logs
+      # Use Postgres 13.4 Docker image as Aurora does not support Postgres 14 yet.
+      run: PGV=13.4 docker-compose up -d
     - name: 'Set up JDK 8'
       uses: actions/setup-java@v1
       with:
@@ -113,7 +114,8 @@ jobs:
           fetch-depth: 50
       - name: Start PostgreSQL
         working-directory: docker
-        run: docker-compose up -d && docker-compose logs
+        # Use Postgres 13.4 Docker image as Aurora does not support Postgres 14 yet.
+        run: PGV=13.4 docker-compose up -d
       - name: 'Set up JDK 11'
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
### Summary

Update GIthub Action step to use the PostgreSQL 13.4 Docker image instead of the latest PostgreSQL version.
Aurora does not support PostgreSQL 14 yet.

### Description

The `pg_hba.conf` used to configure the PostgreSQL database is not compatible with PostgreSQL 14. Starting the PostgreSQL instance with the latest PostgreSQL Docker image (v14+) will cause the database instance to shutdown, this results in the tests failing.

One solution is to update `pg_hba.conf`, but since Aurora does not support PostgreSQL 14 yet, we will use PostgreSQL 13.4 to run the tests.

### Additional Reviewers

@hsuamz 
