### PR TITLE
chore: Update pg_hbc config for compatibility with Postgres 14.

### DIFF
--- a/certdir/server/pg_hba.conf
+++ b/certdir/server/pg_hba.conf
@@ -77,6 +77,6 @@ host    all         postgres    127.0.0.1/32          trust
 host    test	all         127.0.0.1/32          md5
 host    hostdb         all         127.0.0.1/32          md5
 hostnossl    hostnossldb         all         127.0.0.1/32          md5
-hostssl    hostssldb         all         127.0.0.1/32          md5    clientcert=0
-hostssl    hostsslcertdb         all         127.0.0.1/32          md5    clientcert=1
+hostssl    hostssldb         all         127.0.0.1/32          md5    clientcert=verify-ca
+hostssl    hostsslcertdb         all         127.0.0.1/32          md5    clientcert=verify-full
 hostssl    certdb         all         127.0.0.1/32          cert


### PR DESCRIPTION
### Summary

chore: Update pg_hbc config for compatibility with Postgres 14.

### Description
Postgres 14 supports different options for `clientcert`. Instead of `0` or `1`, it requires `verify-ca` or `verify-full`.

https://www.postgresql.org/docs/14/auth-pg-hba-conf.html

### Additional Reviewers