### PR TITLE
chore: Automate maven release

### DIFF
--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -1,0 +1,39 @@
+name: 'Release to Maven'
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  ubuntu-latest-aurora-release-to-maven:
+    name: 'Build And Release to Maven'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Clone Repository'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 50
+      - name: 'Set up JDK 8'
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: 'Build Driver'
+        run: |
+          ./gradlew --no-parallel --no-daemon -x test assemble
+      - name: "Decode Key Ring"
+        run: |
+          echo "${{secrets.GPG_SECRET_KEY_FILE}}" > ~/.gradle/secring.gpg.b64
+          base64 -d ~/.gradle/secring.gpg.b64 > ~/.gradle/secring.gpg
+      - name: 'Install GPG Secret Key'
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: 'Publish to Maven'
+        run: |
+          ./gradlew --no-parallel --no-daemon publishAllPublicationsToOSSRHRepository -Psigning.keyId=${{secrets.GPG_KEY_ID}} -Psigning.password=${{secrets.GPG_PASSPHRASE}} -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg)
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -1,9 +1,9 @@
-name: 'Release Driver'
+name: 'Release Draft'
 
 on:
   push:
     tags:
-      - '*'
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
   actions: write
@@ -29,7 +29,7 @@ jobs:
         S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
       with:
         job-id: jdk8
-        arguments: --no-parallel --no-daemon jandex -x test build
+        arguments: --no-parallel --no-daemon jandex -x test assemble
     - name: 'Set Version Env Variable'
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
     - name: 'Get Release Details'

--- a/pgjdbc/build.gradle.kts
+++ b/pgjdbc/build.gradle.kts
@@ -210,7 +210,6 @@ tasks.shadowJar {
 
 tasks.register<Jar>("cleanShadowJar") {
 
-    archiveClassifier.set("all")
     dependsOn("shadowJar")
     includeEmptyDirs = false
 


### PR DESCRIPTION
### Summary

GitHub Action to automatically build, sign, and publish to Maven Staging

### Description

GitHub Actions `maven_release` automatically builds and signs drivers which are then uploaded to **Maven Staging**.
The following workflow runs whenever a **new release on GitHub is published.**
* Build Driver
* Set-up GPG to be used for signinga
* Publishes signed files to Maven

Once published, it will be in the Staging Repository where you can manually **close** then later **release**.

The following secrets are required for new workflow
* `GPG_SECRET_KEY_FILE `, Base64 encoded GPG secret key
* `GPG_KEY_ID`, the public key ID (Last 8 characters)
* `MAVEN_USERNAME`, Login Username to Nexus Repository Manager
* `MAVEN_USERNAME`, Login Password to Nexus Repository Manager
Existing Secrets that are still required
* `GPG_PRIVATE_KEY `, armor exported GPG secret key
* `GPG_PASSPHRASE`, Passphrase for above key (`GPG_PRIVATE_KEY`)

Minor Change
* Removed `all` from the compiled file name

### Additional Reviewers

@hsuamz 