### PR TITLE
Manually cache GPG passphrase

### DIFF
--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -48,6 +48,8 @@ jobs:
     - name: 'Sign Jars'
       run: |
         export GPG_TTY=$(tty)
+        KEYGRIP="$(gpg --with-keygrip -K | grep -Pom1 '^ *Keygrip += +\K.*')"
+        /usr/lib/gnupg2/gpg-preset-passphrase -c $KEYGRIP <<< ${{ secrets.GPG_PASSPHRASE }}
         for jar in pgjdbc/build/libs/*.jar; do gpg --detach-sign --armor $jar; done
         for signed in pgjdbc/build/libs/*.asc; do gpg --verify $signed; done
     - name: 'Upload to Release'

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -45,6 +45,14 @@ jobs:
       with:
         gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
         passphrase: ${{ secrets.GPG_PASSPHRASE }}
+    - name: 'Trust GPG Key'
+      run: |
+        gpg --no-tty --command-fd 0 --edit-key ${{ steps.import_gpg.outputs.keyid }} << EOTRUST
+        trust
+        5
+        y
+        quit
+        EOTRUST
     - name: 'Sign Jars'
       run: |
         export GPG_TTY=$(tty)


### PR DESCRIPTION
### Summary

Manually cache passphrase.

### Description
GPG signing was previously failing with the error `gpg: signing failed: No such file or directory`.

The error message is actually quite misleading. It didn’t fail because the JAR files do not exist, it failed because it cannot find the passphrase for the the GPG secret key.

When we sign JARs, GPG prompts for the passphrase via a GUI. To automate this process we used a third party Action  crazy-max/ghaction-import-gpg@v4 to preload our passphrase.

Due to the recent updates to the Github Runners, `ghaction-import-gpg` no longer preloads the passphrase, causing GPG to start prompting for a passphrase again. 

The workaround is to do that step ourselves via

/usr/lib/gnupg2/gpg-preset-passphrase -c ${{ secrets.GPG_KEYGRIP }} <<< ${{ secrets.GPG_PASSPHRASE }}

The problem is KEYGRIP changes whenever we re-import the secret key.

We can retrieve the keygrip programmatically via KEYGRIP="$(gpg --with-keygrip -K | grep -Pom1 '^ Keygrip += +\K.')"

### Additional Reviewers

@sergiyvamz 
@ColinKYuen 
@hsuamz 